### PR TITLE
ci: sync main to personal repo for Vercel deploy

### DIFF
--- a/.github/workflows/sync-to-personal.yml
+++ b/.github/workflows/sync-to-personal.yml
@@ -1,0 +1,21 @@
+name: Sync to Personal Repo
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Push to personal repo
+        run: |
+          git remote add personal https://x-access-token:${{ secrets.PERSONAL_REPO_PAT }}@github.com/westkite1201/iidt.git
+          git push personal main --force


### PR DESCRIPTION
## Summary
- 조직 레포 main 브랜치 push 시 개인 레포(`westkite1201/iidt`)로 자동 동기화하는 워크플로우 추가
- Vercel 자동 배포를 위한 인프라 설정
- 기존 AWS CodeDeploy 파이프라인에 영향 없음

## 필요한 설정
- 조직 레포 Secret에 `PERSONAL_REPO_PAT` 추가 필요

## Test plan
- [ ] PR 머지 후 Actions 탭에서 "Sync to Personal Repo" 워크플로우 실행 확인
- [ ] `westkite1201/iidt` 레포에 코드 동기화 확인
- [ ] Vercel 자동 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)