### PR TITLE
refactor: convert static inline styles to Tailwind CSS classes

### DIFF
--- a/src/components/Common/Collapse/index.tsx
+++ b/src/components/Common/Collapse/index.tsx
@@ -24,9 +24,9 @@ const Collapse = ({ title, children, noIcon }: any) => {
   )
 
   return (
-    <div style={{ marginBottom: '12px' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <div style={{ display: 'flex', padding: '5px 0' }}>
+    <div className="mb-3">
+      <div className="flex justify-between items-center">
+        <div className="flex py-[5px]">
           {!noIcon && <div className="flex justify-center items-center px-[5px]">{iconMap?.AlignLeftOutlined}</div>}
           <Text fontSize="16px" bold>
             {title}

--- a/src/components/Common/Text/TooltipText.tsx
+++ b/src/components/Common/Text/TooltipText.tsx
@@ -6,12 +6,8 @@ const TooltipText = forwardRef<HTMLDivElement, React.ComponentProps<typeof Text>
   ({ className, style, ...props }, ref) => (
     <Text
       ref={ref}
-      className={cn(className)}
-      style={{
-        textDecoration: `underline dotted var(--color-text-subtle)`,
-        textUnderlineOffset: '0.1em',
-        ...style,
-      }}
+      className={cn('underline decoration-dotted decoration-[var(--color-text-subtle)] underline-offset-[0.1em]', className)}
+      style={style}
       {...props}
     />
   ),

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,7 +13,7 @@ const Footer = () => {
         IIDT
       </Text>
       <Flex>
-        <Text mr="10px" fontSize="12px" onClick={handleNotion} style={{ cursor: 'pointer' }}>
+        <Text mr="10px" fontSize="12px" onClick={handleNotion} className="cursor-pointer">
           * 팀 소개 | Notion
         </Text>
         <Text mr="10px" fontSize="12px">

--- a/src/components/LoaderPage.tsx
+++ b/src/components/LoaderPage.tsx
@@ -2,13 +2,12 @@ import { Text, Flex } from 'components/Common'
 import PageSection from 'components/PageSection'
 
 const LoaderPage = () => {
-  const PageStyle = { height: '100vh', width: '100%' }
   return (
-    <PageSection innerProps={{ style: PageStyle }} index={1}>
+    <PageSection innerProps={{ className: 'h-screen w-full' }} index={1}>
       <Flex
         justifyContent="center"
         alignItems="center"
-        style={{ height: '100%', width: '100%' }}
+        className="h-full w-full"
         flexDirection="column"
       >
         <div className="animate-spin w-8 h-8 border-4 border-grayscale-7 border-t-transparent rounded-full" />

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -74,10 +74,10 @@ const LoginModal: React.FC<ModalProps> = ({ onDismiss, ...props }) => {
         </LoginButton>
 
         <Box mt="64px" mb="32px">
-          <Text fontSize="10px" color="#A4A2A3" style={{ textDecorationLine: 'underline' }}>
+          <Text fontSize="10px" color="#A4A2A3" className="underline">
             개인정보 처리방침
           </Text>
-          <Text fontSize="10px" color="#A4A2A3" style={{ textDecorationLine: 'underline' }}>
+          <Text fontSize="10px" color="#A4A2A3" className="underline">
             서비스 이용약관
           </Text>
         </Box>

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -158,9 +158,9 @@ const MenuWrapper = ({ themeMode, toggleTheme }) => {
           )}
         >
           <Flex justifyContent="center" alignItems="center">
-            <Flex style={{ cursor: 'pointer', paddingRight: '20px' }}>
+            <Flex className="cursor-pointer pr-5">
               <Link href={isLogin ? '/main' : '/'}>
-                <Heading style={{ fontFamily: 'Cormorant' }}>IIDT</Heading>
+                <Heading className="font-[Cormorant]">IIDT</Heading>
               </Link>
             </Flex>
             <Flex>
@@ -186,7 +186,7 @@ const MenuWrapper = ({ themeMode, toggleTheme }) => {
             <Box width="40px" height="40px" borderRadius="50%"></Box>
             <ThemeToggleButton selected={themeMode === 'dark'} onClick={handleDark} />
             {isLogin ? (
-              <Box onClick={handleMenu} style={{ cursor: 'pointer' }}>
+              <Box onClick={handleMenu} className="cursor-pointer">
                 <MenuOutline stroke={isSharePage && '#fff'} themeMode={themeMode} />
               </Box>
             ) : (

--- a/src/components/WillCard/WillCardHeader.tsx
+++ b/src/components/WillCard/WillCardHeader.tsx
@@ -32,19 +32,19 @@ const MenuWrapper = ({
 const MenuItem = ({ presentDeleteModal, presentShareModal, handleEdit, handlePreview }) => {
   return (
     <Box>
-      <Flex padding="8px" style={{ gap: '8px' }} onClick={handleEdit}>
+      <Flex padding="8px" className="gap-2" onClick={handleEdit}>
         <Edit />
         <Text>수정하기</Text>
       </Flex>
-      <Flex padding="8px" style={{ gap: '8px' }} onClick={presentShareModal}>
+      <Flex padding="8px" className="gap-2" onClick={presentShareModal}>
         <Export />
         <Text>공유하기</Text>
       </Flex>
-      <Flex padding="8px" style={{ gap: '8px' }} onClick={handlePreview}>
+      <Flex padding="8px" className="gap-2" onClick={handlePreview}>
         <Panorama />
         <Text>미리보기</Text>
       </Flex>
-      <Flex padding="8px" style={{ gap: '8px' }} onClick={presentDeleteModal}>
+      <Flex padding="8px" className="gap-2" onClick={presentDeleteModal}>
         <Trash />
         <Text color="#F3213B">삭제하기</Text>
       </Flex>
@@ -94,7 +94,7 @@ const Header = ({ will, handleDelete, handleShare, isPrivate = true }: HeaderPro
       <Flex justifyContent="space-between" alignItems="center">
         <Text>{moment(regDate).format('YYYY.MM.DD')}</Text>
         {isLogin && (
-          <Text style={{ cursor: 'pointer' }} onClick={handleIsOpen} ref={setTargetRef}>
+          <Text className="cursor-pointer" onClick={handleIsOpen} ref={setTargetRef}>
             {isPrivate && (
               <>
                 <Ellipsis />

--- a/src/components/WillCard/index.tsx
+++ b/src/components/WillCard/index.tsx
@@ -62,7 +62,7 @@ const WillCard = ({ will, handleDelete, handleShare, isPrivate = true }: WillCar
           left="45%"
           onClick={handleIsOpen}
         >
-          <MoreOutlined style={{ fontSize: '40px', cursor: 'pointer' }} />
+          <MoreOutlined className="text-[40px] cursor-pointer" />
         </Box>
       )}
       {isOverflowContent?.current && !isOverflow && (
@@ -73,7 +73,7 @@ const WillCard = ({ will, handleDelete, handleShare, isPrivate = true }: WillCar
           left="45%"
           onClick={handleIsOpen}
         >
-          <CaretUpOutlined style={{ fontSize: '30px', cursor: 'pointer' }} />
+          <CaretUpOutlined className="text-[30px] cursor-pointer" />
         </Box>
       )}
     </Box>

--- a/src/contexts/Toast.tsx
+++ b/src/contexts/Toast.tsx
@@ -36,8 +36,8 @@ export const CustomToast = (props) => {
   return (
     <div className="bg-[#191919]">
       <div className="flex justify-between items-center">
-        <span style={{ fontFamily: 'SUIT', color: '#fff' }}>{props.message}</span>
-        <span style={{ fontFamily: 'SUIT', color: '#fff' }}>닫기</span>
+        <span className="font-[SUIT] text-white">{props.message}</span>
+        <span className="font-[SUIT] text-white">닫기</span>
       </div>
     </div>
   )

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -187,7 +187,7 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
   )
 
   if (!mounted) {
-    return <div style={{ visibility: 'hidden' }}>{body}</div>
+    return <div className="invisible">{body}</div>
   }
   return <>{body}</>
 }

--- a/src/views/About/index.tsx
+++ b/src/views/About/index.tsx
@@ -45,7 +45,7 @@ const AboutPage = () => {
 
   return (
     <Page title={ABOUT_INFO.TITLE} content={ABOUT_INFO.CONTENT} isFullPage>
-      <div style={{ minHeight: 'calc(100% - 231px)' }}>
+      <div className="min-h-[calc(100%-231px)]">
         <WillTitle />
         <WillContent />
       </div>

--- a/src/views/Home/components/CountDown.tsx
+++ b/src/views/Home/components/CountDown.tsx
@@ -23,14 +23,7 @@ const CountDown = ({ height = '550px', isCountDown = true, text = '' }) => {
         <img
           src="/images/home/matthew-mendez.jpg"
           alt="road"
-          style={{
-            position: 'absolute',
-            width: '100%',
-            height: '100%',
-            zIndex: '-1',
-            objectFit: 'cover',
-            filter: 'blur(2px)',
-          }}
+          className="absolute w-full h-full -z-[1] object-cover blur-[2px]"
         />
         <Box width="100%" height={height} position="relative">
           <Flex justifyContent="center" alignItems="center" height="100%" position="relative">

--- a/src/views/Home/components/MainCard.tsx
+++ b/src/views/Home/components/MainCard.tsx
@@ -20,14 +20,7 @@ const Card = ({
         isFill
         src={imagePath}
         alt={alt}
-        style={{
-          position: 'absolute',
-          width: '100%',
-          height: '100%',
-          zIndex: '-1',
-          objectFit: 'cover',
-          filter: 'blur(2px)',
-        }}
+        className="absolute w-full h-full -z-[1] object-cover blur-[2px]"
       />
 
       <Box width="100%" height={`${height}px`} position="relative">

--- a/src/views/Home/components/Typing.tsx
+++ b/src/views/Home/components/Typing.tsx
@@ -51,7 +51,7 @@ const TypingTest = ({ str = '타이핑 컴포넌트 입니다', handleStatus, st
   }, [disassembled, handleStatus])
 
   return (
-    <span style={{ height: '100%' }} className={classNames({ 'typing_with-blinking-cursor': status !== 'is_done' })}>
+    <span className={classNames('h-full', { 'typing_with-blinking-cursor': status !== 'is_done' })}>
       {result}
     </span>
   )

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -19,12 +19,9 @@ export const MainButton = ({
       'w-[335px] h-[50px] sm:h-[44px]',
       'rounded border-none cursor-pointer font-[SUIT]',
       'flex-none order-0 grow',
+      'bg-[var(--color-contrast)] text-[var(--color-bg)]',
       className,
     )}
-    style={{
-      background: 'var(--color-contrast)',
-      color: 'var(--color-bg)',
-    }}
     {...props}
   />
 )
@@ -79,7 +76,7 @@ const Home: React.FC = () => {
           alt=""
         />
 
-        <Box mb="50px" style={{ textAlign: 'center' }} height="100vh">
+        <Box mb="50px" className="text-center" height="100vh">
           <Flex justifyContent="center" alignItems="center" height="100%" position="relative" flexDirection="column">
             <Text className="text-[16px] md:text-[36px]" data-aos="fade-up" data-aos-duration="1000">
               만약 내일 생을 마감한다면,
@@ -96,7 +93,7 @@ const Home: React.FC = () => {
           </Flex>
         </Box>
 
-        <Box mb="50px" style={{ textAlign: 'center' }}>
+        <Box mb="50px" className="text-center">
           <Flex justifyContent="center" flexDirection="column" alignItems="center">
             <Text className="text-[16px] md:text-[36px] lg:text-[48px]" mb="24px">
               다시 한 번 삶을 되돌아보는 시간
@@ -108,7 +105,7 @@ const Home: React.FC = () => {
         </Box>
       </Box>
 
-      <div style={{ marginBottom: '50px' }}></div>
+      <div className="mb-[50px]"></div>
     </>
   )
 }

--- a/src/views/Main/components/BannerCard.tsx
+++ b/src/views/Main/components/BannerCard.tsx
@@ -71,13 +71,7 @@ const BannerCard = ({ height = '231px' }) => {
             height="100%"
             position="relative"
             background="inherit"
-            style={{
-              color: 'transparent',
-              WebkitBackgroundClip: 'text',
-              backgroundClip: 'text',
-              textAlign: 'center',
-              filter: 'invert(1) grayscale(1) contrast(7) drop-shadow(2px 2px 2px black)',
-            }}
+            className="text-transparent bg-clip-text text-center [filter:invert(1)_grayscale(1)_contrast(7)_drop-shadow(2px_2px_2px_black)]"
           >
             <Text className="dark:px-2.5 text-[14px] lg:text-[18px]" color="inherit" bold>
               {firstLine}

--- a/src/views/Main/components/modal/ShareModal.tsx
+++ b/src/views/Main/components/modal/ShareModal.tsx
@@ -73,7 +73,7 @@ const ShareModal = ({ onDismiss, content, willId, title, ...props }: any) => {
         <Text mb="20px">마음이 힘들다면 1577-0199로 전화해주세요.</Text>
         <Text mb="20px">당신은 그 누구보다 소중합니다.</Text>
         <Box>
-          <Flex justifyContent="center" alignItems="center" flexWrap="wrap" style={{ gap: '10px' }}>
+          <Flex justifyContent="center" alignItems="center" flexWrap="wrap" className="gap-2.5">
             <CopyToClipboard toCopy={`${API_URL}/will/${willId}`} />
             <div onClick={handleKakao} type="button">
               <img alt="" src="//developers.kakao.com/assets/img/about/logos/kakaolink/kakaolink_btn_small.png" />

--- a/src/views/Main/components/modal/WriteDeleteModal.tsx
+++ b/src/views/Main/components/modal/WriteDeleteModal.tsx
@@ -26,7 +26,7 @@ const WriteDeleteModal = ({ onDismiss, ...props }: any) => {
         <Text>삭제한 유서는 복구할 수 없어요</Text>
         <Text>하지만 이 유서를 통해 하루하루의 삶이 빛나고 소중해졌다면 삭제해도 좋아요</Text>
         <Box mt="20px">
-          <Flex style={{ gap: '8px' }}>
+          <Flex className="gap-2">
             <ConfirmButton background="grey" onClick={onDismiss}>
               나중에 할게요
             </ConfirmButton>

--- a/src/views/Main/index.tsx
+++ b/src/views/Main/index.tsx
@@ -107,7 +107,7 @@ const Main = () => {
   }
 
   return (
-    <Box mt="78px" style={{ minHeight: 'calc(100% - 231px)' }}>
+    <Box mt="78px" className="min-h-[calc(100%-231px)]">
       <Box mb="36px">
         <BannerCard />
       </Box>

--- a/src/views/Memorials/components/BannerCard.tsx
+++ b/src/views/Memorials/components/BannerCard.tsx
@@ -71,13 +71,7 @@ const BannerCard = ({ height = '231px' }) => {
             height="100%"
             position="relative"
             background="inherit"
-            style={{
-              color: 'transparent',
-              WebkitBackgroundClip: 'text',
-              backgroundClip: 'text',
-              textAlign: 'center',
-              filter: 'invert(1) grayscale(1) contrast(7) drop-shadow(2px 2px 2px black)',
-            }}
+            className="text-transparent bg-clip-text text-center [filter:invert(1)_grayscale(1)_contrast(7)_drop-shadow(2px_2px_2px_black)]"
           >
             <Text className="dark:px-2.5 text-[14px] lg:text-[18px]" color="inherit" bold>
               {firstLine}

--- a/src/views/Memorials/components/modal/ShareModal.tsx
+++ b/src/views/Memorials/components/modal/ShareModal.tsx
@@ -73,7 +73,7 @@ const ShareModal = ({ onDismiss, content, willId, title, ...props }: any) => {
         <Text mb="20px">마음이 힘들다면 1577-0199로 전화해주세요.</Text>
         <Text mb="20px">당신은 그 누구보다 소중합니다.</Text>
         <Box>
-          <Flex justifyContent="center" alignItems="center" flexWrap="wrap" style={{ gap: '10px' }}>
+          <Flex justifyContent="center" alignItems="center" flexWrap="wrap" className="gap-2.5">
             <CopyToClipboard toCopy={`${API_URL}/will/${willId}`} />
             <div onClick={handleKakao}>
               <img alt="" src="//developers.kakao.com/assets/img/about/logos/kakaolink/kakaolink_btn_small.png" />

--- a/src/views/Memorials/components/modal/WriteDeleteModal.tsx
+++ b/src/views/Memorials/components/modal/WriteDeleteModal.tsx
@@ -26,7 +26,7 @@ const WriteDeleteModal = ({ onDismiss, ...props }: any) => {
         <Text>삭제한 유서는 복구할 수 없어요</Text>
         <Text>하지만 이 유서를 통해 하루하루의 삶이 빛나고 소중해졌다면 삭제해도 좋아요</Text>
         <Box mt="20px">
-          <Flex style={{ gap: '8px' }}>
+          <Flex className="gap-2">
             <ConfirmButton background="grey" onClick={onDismiss}>
               나중에 할게요
             </ConfirmButton>

--- a/src/views/Memorials/index.tsx
+++ b/src/views/Memorials/index.tsx
@@ -170,7 +170,7 @@ const WillContainer = () => {
 
 const Memorials = () => {
   return (
-    <Box mt="78px" style={{ minHeight: 'calc(100% - 231px)' }}>
+    <Box mt="78px" className="min-h-[calc(100%-231px)]">
       <Flex flexDirection="column" justifyContent="center" alignItems="center">
         <Flex flexDirection="column" justifyContent="center" alignItems="center">
           <WillContainer />

--- a/src/views/NotFound.tsx
+++ b/src/views/NotFound.tsx
@@ -4,13 +4,10 @@ import { MainButton } from 'views/Home'
 
 const NotFound = () => {
   return (
-    <Box style={{ minHeight: 'calc(100vh - 64px)', justifyContent: 'center', alignItems: 'center', display: 'flex' }}>
+    <Box className="min-h-[calc(100vh-64px)] flex justify-center items-center">
       <Box
+        className="w-full min-h-[calc(100vh-64px)] absolute -z-[1]"
         style={{
-          width: '100%',
-          minHeight: 'calc(100vh - 64px)',
-          position: 'absolute',
-          zIndex: '-1',
           background:
             'linear-gradient(0deg, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.6)), url(/images/home/joshua-sortino-XMcoTHgNcQA-unsplash.jpg)',
         }}
@@ -19,20 +16,20 @@ const NotFound = () => {
         <Text fontSize="36px" mb="18px">
           길을 잃으셨나요?
         </Text>
-        <Text style={{ fontFamily: 'SUIT' }}> 괜찮아요. 저희가 안내할게요.</Text>
-        <Text style={{ fontFamily: 'SUIT' }}> 찾으시는 페이지의 주소가 잘못 입력되었거나,</Text>
-        <Text style={{ fontFamily: 'SUIT' }} mb="18px">
+        <Text className="font-[SUIT]"> 괜찮아요. 저희가 안내할게요.</Text>
+        <Text className="font-[SUIT]"> 찾으시는 페이지의 주소가 잘못 입력되었거나,</Text>
+        <Text className="font-[SUIT]" mb="18px">
           주소의 변경 혹은 삭제로 인해 사용하실수 없습니다.
         </Text>
 
-        <Text style={{ fontFamily: 'SUIT' }}>
+        <Text className="font-[SUIT]">
           입력하신 페이지의 주소가 정확한지 다시 한 번 획인해주시고, 같은 문제가 또 발생한다면
         </Text>
-        <Text style={{ fontFamily: 'SUIT' }} mb="18px">
+        <Text className="font-[SUIT]" mb="18px">
           ifteam@gmail.com으로 알려주세요.
         </Text>
         <Link href="/">
-          <MainButton style={{ fontFamily: 'SUIT' }}>홈으로 가기</MainButton>
+          <MainButton className="font-[SUIT]">홈으로 가기</MainButton>
         </Link>
       </div>
     </Box>

--- a/src/views/Will/components/CopyToClipboard.tsx
+++ b/src/views/Will/components/CopyToClipboard.tsx
@@ -28,8 +28,7 @@ const CopyToClipboard: React.FC<Props> = ({ toCopy, ...props }) => {
   return (
     <div
       role="button"
-      className="relative flex items-center cursor-pointer"
-      style={{ color: 'var(--color-primary)' }}
+      className="relative flex items-center cursor-pointer text-[var(--color-primary)]"
       onClick={() => {
         if (navigator.clipboard && navigator.permissions) {
           navigator.clipboard.writeText(toCopy).then(() => displayTooltip())
@@ -40,16 +39,15 @@ const CopyToClipboard: React.FC<Props> = ({ toCopy, ...props }) => {
       }}
       {...props}
     >
-      <LinkOutlined style={{ width: '40px', height: '40px', fontSize: '32px', color: '#000' }} />
+      <LinkOutlined className="w-10 h-10 text-[32px] text-black" />
       <div
         className={cn(
           'absolute bottom-[-22px] right-0 left-0 text-center w-20 rounded transition-all duration-600',
+          'bg-[var(--color-contrast)] text-[var(--color-inverted-contrast)]',
+          'shadow-[0px_20px_36px_-8px_rgb(14_14_44/10%),0px_1px_1px_rgb(0_0_0/5%)]',
         )}
         style={{
           opacity: isTooltipDisplayed ? 0.7 : 0,
-          backgroundColor: 'var(--color-contrast)',
-          color: 'var(--color-inverted-contrast)',
-          boxShadow: '0px 20px 36px -8px rgb(14 14 44 / 10%), 0px 1px 1px rgb(0 0 0 / 5%)',
         }}
       >
         복사 완료.

--- a/src/views/Will/components/TitleBanner.tsx
+++ b/src/views/Will/components/TitleBanner.tsx
@@ -26,21 +26,12 @@ const TitleBanner = ({ height, title, date, imagePath }: TitleBannerProps) => {
           src={imagePath}
           alt={'jms-ZfVqAKZ4YRQ-unsplash'}
           position="fixed"
-          style={{
-            position: 'absolute',
-            width: '100%',
-            height: '100%',
-            zIndex: '-1',
-            objectFit: 'cover',
-            background: 'linear-gradient(0deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.2))',
-            clipPath: 'inset(0)',
-          }}
+          className="absolute w-full h-full -z-[1] object-cover bg-[linear-gradient(0deg,rgba(255,255,255,0.2),rgba(255,255,255,0.2))] [clip-path:inset(0)]"
         />
         <Box width="100%" height={height} position="relative">
           <Flex flexDirection="column" justifyContent="center" alignItems="center" height="100%" position="relative">
             <div
-              className="dark:px-2.5 text-[18px] lg:text-[32px] font-semibold bg-black text-white w-4/5 text-center"
-              style={{ lineHeight: 1.5 }}
+              className="dark:px-2.5 text-[18px] lg:text-[32px] font-semibold bg-black text-white w-4/5 text-center leading-normal"
             >
               <span className="text-white">
                 <Typing str={title} handleStatus={handleStatus} status={status} />
@@ -48,12 +39,11 @@ const TitleBanner = ({ height, title, date, imagePath }: TitleBannerProps) => {
             </div>
             <div
               className={cn(
-                'dark:px-2.5 text-[14px] lg:text-[18px] font-semibold text-white transition-all duration-1000',
+                'dark:px-2.5 text-[14px] lg:text-[18px] font-semibold text-white transition-all duration-1000 leading-normal',
                 status === 'is_done'
                   ? 'opacity-100 translate-y-0'
                   : 'opacity-0 translate-y-[15px]',
               )}
-              style={{ lineHeight: 1.5 }}
             >
               {moment(date).format('YYYY년 MM월 DD일 hh시 mm분')}
             </div>

--- a/src/views/Will/components/WillShareCard.tsx
+++ b/src/views/Will/components/WillShareCard.tsx
@@ -20,22 +20,18 @@ const WillCard = ({ will, isDisplayHeader = true }: WillCardProps) => {
 
   return (
     <Box
-      className="box"
+      className="box bg-[var(--color-bg)]"
       mb="40px"
       padding="20px"
       minWidth="362px"
       maxWidth="582px"
       borderRadius="4px"
-      style={{ background: 'var(--color-bg)' }}
     >
       <Box data-aos="fade" data-aos-duration="2500">
         {isDisplayHeader && (
           <Box
             height="25px"
-            style={{
-              boxShadow: '0 -1px 4px rgb(0 0 0 / 70%)',
-              background: 'var(--color-contrast)',
-            }}
+            className="shadow-[0_-1px_4px_rgb(0_0_0/70%)] bg-[var(--color-contrast)]"
           >
             <Text color="#fff" fontSize="18px" textAlign="center">
               마지막으로...

--- a/src/views/Will/index.tsx
+++ b/src/views/Will/index.tsx
@@ -86,7 +86,7 @@ const WillPage = () => {
 
   return (
     <Page title={data?.TITLE} content={data?.CONTENT} isFullPage>
-      <Box style={{ minHeight: 'calc(100% - 231px)' }}>
+      <Box className="min-h-[calc(100%-231px)]">
         <WillTitle data={data} />
         <WillContent data={data} isLoading={isLoading} />
         <WillFooter handleWrite={handleWrite} />

--- a/src/views/Write/components/modal/SelectPostTypeModal.tsx
+++ b/src/views/Write/components/modal/SelectPostTypeModal.tsx
@@ -39,7 +39,7 @@ const SelectPostTypeModal = ({ handlePostType, onDismiss }: customModalProps) =>
     <Modal title="일기 작성 방식을 선택할 수 있어요" onDismiss={onDismiss}>
       <Flex flexDirection="column" justifyContent="center" alignItems="center">
         <Box mb="20px">
-          <Flex justifyContent="center" flexDirection="column" style={{ textAlign: 'center', wordBreak: 'keep-all' }}>
+          <Flex justifyContent="center" flexDirection="column" className="text-center break-keep">
             <Text fontSize={['13px', , '18px']}>
               오늘 유서를 처음 작성하시는 분들을 위해 두 가지의 선택방식을 두었어요.
             </Text>

--- a/src/views/Write/components/modal/WarningHistoryBackModal.tsx
+++ b/src/views/Write/components/modal/WarningHistoryBackModal.tsx
@@ -40,7 +40,7 @@ const WarningHistoryBackModal = ({ onDismiss, ...props }: any) => {
           지금까지 작성된 내용은 저장되지 않습니다
         </Text>
         <Box mt="20px">
-          <Flex style={{ gap: '8px' }}>
+          <Flex className="gap-2">
             <ConfirmButton onClick={handleGoToMain}>나중에 다시 쓸게요</ConfirmButton>
             <ConfirmButton variant="primary" onClick={onDismiss}>
               지금 계속 쓸게요

--- a/src/views/Write/index.tsx
+++ b/src/views/Write/index.tsx
@@ -141,9 +141,9 @@ const Write = () => {
 
   return (
     <article
+      className="relative"
       style={{
         marginTop: `${MENU_HEIGHT}px`,
-        position: 'relative',
         height: `calc(100vh - ${MENU_HEIGHT}px - ${FOOTER_HEIGHT}px)`,
       }}
     >
@@ -172,14 +172,13 @@ const Write = () => {
             'font-[Nanum_Myeongjo] text-[var(--color-text-secondary)]',
             'placeholder:text-[var(--color-grayscale-5)]',
             'sm:text-[16px] md:text-[26px]',
+            'h-[30px] mb-6 overflow-hidden',
           )}
-          style={{ height: '30px', marginBottom: '24px', overflow: 'hidden' }}
         />
 
         {isDefaultPostType || (
           <div
-            className="font-[Nanum_Myeongjo] font-bold text-[26px] mb-4 sm:text-[16px] md:text-[26px]"
-            style={{ color: 'var(--color-text-primary)' }}
+            className="font-[Nanum_Myeongjo] font-bold text-[26px] mb-4 sm:text-[16px] md:text-[26px] text-[var(--color-text-primary)]"
           >
             {QUESTION_LIST[page]?.question}
           </div>
@@ -202,7 +201,7 @@ const Write = () => {
             variant="primary"
             onClick={handleUpsert}
             disabled={false}
-            style={{ marginBottom: '16px' }}
+            className="mb-4"
           >
             작성 완료
           </StyleMenuButton>
@@ -213,7 +212,7 @@ const Write = () => {
             variant="primary"
             onClick={handleUpsert}
             disabled={isDisableSave}
-            style={{ marginBottom: '16px' }}
+            className="mb-4"
           >
             모두 다 작성했어요
           </StyleMenuButton>


### PR DESCRIPTION
## Summary
- 31개 파일에서 ~60개의 정적 `style={{ }}` 인라인 스타일을 Tailwind CSS 유틸리티 클래스로 변환
- 동적/런타임 값에 의존하는 인라인 스타일은 의도적으로 유지
- 코어 컴포넌트(Box, Flex, Grid, Text 등)의 `extractStyleProps` 패턴은 유지

### 주요 변환 패턴
- `cursor: 'pointer'` → `cursor-pointer`
- `gap: '8px'` → `gap-2`
- `fontFamily: 'SUIT'` → `font-[SUIT]`
- `textDecorationLine: 'underline'` → `underline`
- `visibility: 'hidden'` → `invisible`
- `position/width/height/zIndex/objectFit/filter` 블록 → Tailwind 클래스 조합
- `minHeight: 'calc(...)'` → `min-h-[calc(...)]`
- CSS 변수 값 → `bg-[var(--color-*)]`, `text-[var(--color-*)]`
- `backgroundClip/filter` 복합 속성 → `bg-clip-text [filter:...]`

## Test plan
- [ ] 주요 페이지 (Home, Write, Will, Memorials, Main, About, NotFound) 시각적 확인
- [ ] 다크 모드 전환 확인
- [ ] 모바일/데스크톱 반응형 확인
- [ ] 빌드 성공 확인 (`yarn build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)