### PR TITLE
refactor: SEO, 코드 품질, 접근성 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,10 @@ src/
 - `AUTH_KAKAO_ID` / `AUTH_KAKAO_SECRET` - Kakao OAuth
 - `AUTH_NAVER_ID` / `AUTH_NAVER_SECRET` - Naver OAuth
 - `NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` - Supabase 연결
+- `NEXT_PUBLIC_SITE_URL` - 사이트 URL (OG 메타 태그용)
+
+## PR 기록
+
+| 날짜 | 주제 | 문서 |
+|------|------|------|
+| 2026-03-08 | SEO, 코드 품질, 접근성 개선 | [docs/pr/2026-03-08-seo-code-quality-a11y.md](docs/pr/2026-03-08-seo-code-quality-a11y.md) |

--- a/docs/pr/2026-03-08-seo-code-quality-a11y.md
+++ b/docs/pr/2026-03-08-seo-code-quality-a11y.md
@@ -1,0 +1,69 @@
+# PR 기록: SEO, 코드 품질, 접근성 개선
+- 날짜: 2026-03-08
+- 브랜치: westkite1201/iidt-front-end/explore-kicks
+- 변경 파일 수: 27 (25 수정 + 2 신규)
+- 요약:
+  - 프로덕션 코드에 남아있던 console.log 11개 제거
+  - SEOHead 컴포넌트 신규 생성으로 페이지별 동적 메타 태그(OG, Twitter) 지원
+  - ErrorBoundary 추가로 런타임 에러 시 폴백 UI 제공
+  - WCAG Level A 접근성 개선: lang 속성, ARIA 라벨, 시맨틱 HTML 태그
+  - 빈 alt 속성 수정, 배열 인덱스 키 수정 등 코드 품질 향상
+
+## 진행상황 (Done)
+- console.log/console.error 11개 제거 (_app.tsx, WillCard, Menu, MenuWrapper, mutation hooks)
+- ErrorBoundary 컴포넌트 생성 및 _app.tsx에 래핑
+- SEOHead 컴포넌트 생성 (동적 og/twitter 메타 태그)
+- Page.tsx의 PageMeta를 SEOHead로 교체 (og:title undefined 버그 수정)
+- _app.tsx 빈 Twitter 메타 태그 제거
+- 페이지별 SEOHead 추가 (index, about, onboarding, 404)
+- meta.ts 보강 (SITE_NAME/URL, 홈 경로 추가, null 반환 제거)
+- 빈 alt 속성 4개 수정
+- lang="ko" 추가
+- 모달 role="dialog", aria-modal 추가
+- 메뉴 버튼 시맨틱화 (Box → button + aria-label/aria-expanded)
+- Footer 시맨틱화 (footer 태그, a 링크)
+- main 태그 추가
+- ThemeToggleButton, PrivateToggle aria-label 추가
+- WriteDeleteModal ConfirmButton div → button 변환
+- Button 컴포넌트 focus-visible 포커스 인디케이터 추가
+- DropdownMenu 배열 인덱스 키 수정
+- onboarding 폼 label + role="alert" 추가
+
+## 할 일 (Next)
+- [ ] 로컬 빌드 검증 (node_modules 설치 후)
+- [ ] Lighthouse 접근성 점수 비교 (개선 전/후)
+- [ ] NEXT_PUBLIC_SITE_URL 환경변수 설정
+
+## 우리가 검토한 것 / 결정 사항
+- SEOHead를 별도 컴포넌트로 분리하여 재사용성 확보 (Page 래퍼 없는 페이지에서도 사용 가능)
+- console.error도 제거: React Query의 onError + 토스트가 이미 에러를 처리하므로 중복
+- ErrorBoundary는 providers 안, 콘텐츠 바깥에 배치하여 전체 앱 크래시 방어
+
+## 참고 아티클 / 레퍼런스
+- 제목: WCAG 2.1 Quick Reference
+  - 링크: https://www.w3.org/WAI/WCAG21/quickref/
+  - 한줄 요약: 접근성 기준 가이드라인
+- 제목: Next.js Head Component
+  - 링크: https://nextjs.org/docs/pages/api-reference/components/head
+  - 한줄 요약: Pages Router에서 페이지별 메타 태그 관리
+
+## research.md 업데이트
+- 상태: NO
+- 근거:
+  - DB/마이그레이션/인증/비동기 흐름 변경 없음
+  - 순수 프론트엔드 UI/SEO/접근성 개선
+- 액션:
+  - [x] 생략
+
+## 변경 파일(참고)
+- 신규: src/components/Common/ErrorBoundary/index.tsx, src/components/SEO/SEOHead.tsx
+- 수정: src/pages/_app.tsx, src/pages/_document.tsx, src/pages/index.tsx, src/pages/about.tsx, src/pages/onboarding.tsx
+- 수정: src/components/Layout/Page.tsx, src/components/Menu/index.tsx, src/components/Menu/DropdownMenu.tsx
+- 수정: src/components/Footer.tsx, src/components/MenuWrapper.tsx, src/components/WillCard/index.tsx
+- 수정: src/components/Common/Button/Button.tsx, src/components/Common/Button/ThemeToggleButton.tsx
+- 수정: src/components/Common/Modal/ModalContext.tsx, src/components/PrivateToggle.tsx
+- 수정: src/config/constants/meta.ts
+- 수정: src/queries/will/mutations/use-create-will.ts, use-delete-will.ts, use-update-will.ts
+- 수정: src/views/Home/index.tsx, src/views/NotFound.tsx
+- 수정: src/views/Main/components/modal/ShareModal.tsx, WriteDeleteModal.tsx
+- 수정: src/views/Memorials/components/modal/ShareModal.tsx, WriteDeleteModal.tsx

--- a/src/components/Common/Button/Button.tsx
+++ b/src/components/Common/Button/Button.tsx
@@ -29,7 +29,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps<'button'>>(
         className={cn(
           // Base styles
           'inline-flex items-center justify-center',
-          'outline-none border-none box-border',
+          'outline-none border-none box-border focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-current',
           'text-xs xl:text-sm font-semibold leading-none',
           'rounded cursor-pointer',
           'transition-colors duration-200',

--- a/src/components/Common/Button/ThemeToggleButton.tsx
+++ b/src/components/Common/Button/ThemeToggleButton.tsx
@@ -9,7 +9,11 @@ interface ToggleButtonProps {
 const ThemeToggleButton = (props: ToggleButtonProps) => {
   const { selected } = props
   return (
-    <button className="w-8 h-8 flex items-center justify-center border-none rounded-[2rem] cursor-pointer bg-transparent" {...props}>
+    <button
+      className="w-8 h-8 flex items-center justify-center border-none rounded-[2rem] cursor-pointer bg-transparent"
+      aria-label={selected ? '라이트 모드로 전환' : '다크 모드로 전환'}
+      {...props}
+    >
       <div
         className={cn(
           'absolute transition-[visibility] duration-150 ease-out',

--- a/src/components/Common/ErrorBoundary/index.tsx
+++ b/src/components/Common/ErrorBoundary/index.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('ErrorBoundary caught:', error, errorInfo)
+    }
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center min-h-screen p-5 text-center">
+          <h2 className="text-2xl font-[Nanum_Myeongjo] mb-4">문제가 발생했습니다</h2>
+          <p className="text-[var(--color-text-subtle)] mb-6">
+            일시적인 오류가 발생했습니다. 다시 시도해주세요.
+          </p>
+          <button
+            onClick={this.handleReset}
+            className="px-6 py-2 border border-current rounded cursor-pointer bg-inherit text-inherit"
+          >
+            다시 시도
+          </button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/components/Common/Modal/ModalContext.tsx
+++ b/src/components/Common/Modal/ModalContext.tsx
@@ -83,6 +83,8 @@ const ModalProvider = ({ children }: ModalProviderProps) => {
               {/* Modal Content */}
               <m.div
                 className="relative z-10"
+                role="dialog"
+                aria-modal="true"
                 initial={{ scale: 0.95, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 exit={{ scale: 0.95, opacity: 0 }}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,26 +1,29 @@
-import { Box, Text, Flex } from 'components/Common'
+import { Text, Flex } from 'components/Common'
 import { FOOTER_HEIGHT } from 'config/constants/default'
 
 const Footer = () => {
-  const handleNotion = () => {
-    window.open('https://iidtcrew.notion.site/IIDT-CREW-74a141ff2a93486594249a8c84fe9270', '_blank')
-  }
-
   return (
-    <Box height={`${FOOTER_HEIGHT}px`} padding="20px" borderTop="1px solid #D4D4D4 " borderBottom="none">
-      {/* <Text fontSize="12px">개인정보수집방침 이용약관</Text> */}
+    <footer
+      className="border-t border-[#D4D4D4] border-b-0 p-5"
+      style={{ height: `${FOOTER_HEIGHT}px` }}
+    >
       <Text fontSize="12px" mr="10px">
         IIDT
       </Text>
       <Flex>
-        <Text mr="10px" fontSize="12px" onClick={handleNotion} className="cursor-pointer">
+        <a
+          href="https://iidtcrew.notion.site/IIDT-CREW-74a141ff2a93486594249a8c84fe9270"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mr-2.5 text-xs cursor-pointer text-inherit no-underline"
+        >
           * 팀 소개 | Notion
-        </Text>
+        </a>
         <Text mr="10px" fontSize="12px">
           * Email | iidtcrew@gmail.com
         </Text>
       </Flex>
-    </Box>
+    </footer>
   )
 }
 

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -1,24 +1,5 @@
-import Head from 'next/head'
-import { useRouter } from 'next/router'
-import { DEFAULT_META, getCustomMeta } from 'config/constants/meta'
+import SEOHead from 'components/SEO/SEOHead'
 import cn from 'utils/cn'
-
-export const PageMeta: React.FC<{ title?: string; content?: string }> = ({ title: mainTitle, content }) => {
-  const { pathname } = useRouter()
-
-  const pageMeta = getCustomMeta(pathname) || {}
-  const { title, description, image } = { ...DEFAULT_META, ...pageMeta }
-  const pageTitle = title
-
-  return (
-    <Head>
-      <title>{pageTitle}</title>
-      <meta property="og:title" content={mainTitle} />
-      <meta property="og:description" content={content ? content : description} />
-      <meta property="og:image" content={image} />
-    </Head>
-  )
-}
 
 interface PageProps extends React.HTMLAttributes<HTMLDivElement> {
   title?: string
@@ -29,7 +10,7 @@ interface PageProps extends React.HTMLAttributes<HTMLDivElement> {
 const Page: React.FC<PageProps> = ({ children, title, content, isFullPage = false, className, ...props }) => {
   return (
     <>
-      <PageMeta title={title} content={content} />
+      <SEOHead title={title} description={content} />
       <div
         className={cn(
           'sm:pt-[50px] sm:pb-6 lg:pt-[50px] lg:pb-8',

--- a/src/components/Menu/DropdownMenu.tsx
+++ b/src/components/Menu/DropdownMenu.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-array-index-key */
 import React, { useEffect, useState } from 'react'
 import { usePopper } from 'react-popper'
 import useOnClickOutside from 'hooks/useOnClickOutside'
@@ -152,7 +151,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
         >
           {items
             .filter((item) => !item.isMobileOnly)
-            .map(({ type = DropdownMenuItemType.INTERNAL_LINK, label, href = '/', status, ...itemProps }, itemItem) => {
+            .map(({ type = DropdownMenuItemType.INTERNAL_LINK, label, href = '/', status, ...itemProps }) => {
               const MenuItemContent = (
                 <>
                   {label}
@@ -165,7 +164,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
               )
               const isActive = href === activeItem
               return (
-                <StyledDropdownMenuItemContainer key={itemItem}>
+                <StyledDropdownMenuItemContainer key={`${label}-${href}`}>
                   <DropdownMenuItem isActive={isActive} type="button" {...itemProps}>
                     <Link href={href}>{MenuItemContent}</Link>
                   </DropdownMenuItem>

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -73,8 +73,8 @@ const MenuBox = () => {
     try {
       dispatch(naviActions.menuOnOff())
       await signOut({ callbackUrl: '/' })
-    } catch (e) {
-      console.log('logout ', e)
+    } catch {
+      // sign out failed silently
     }
   }
 
@@ -186,9 +186,14 @@ const MenuWrapper = ({ themeMode, toggleTheme }) => {
             <Box width="40px" height="40px" borderRadius="50%"></Box>
             <ThemeToggleButton selected={themeMode === 'dark'} onClick={handleDark} />
             {isLogin ? (
-              <Box onClick={handleMenu} className="cursor-pointer">
+              <button
+                onClick={handleMenu}
+                className="cursor-pointer bg-transparent border-none p-0"
+                aria-label="메뉴 열기"
+                aria-expanded={isMenuOpen}
+              >
                 <MenuOutline stroke={isSharePage && '#fff'} themeMode={themeMode} />
-              </Box>
+              </button>
             ) : (
               <Button onClick={handleLogin}>시작하기</Button>
             )}

--- a/src/components/MenuWrapper.tsx
+++ b/src/components/MenuWrapper.tsx
@@ -18,8 +18,8 @@ const MenuWrapper = () => {
     try {
       dispatch(naviActions.menuOnOff())
       await signOut({ callbackUrl: '/' })
-    } catch (e) {
-      console.log('logout ', e)
+    } catch {
+      // sign out failed silently
     }
   }
 

--- a/src/components/PrivateToggle.tsx
+++ b/src/components/PrivateToggle.tsx
@@ -10,6 +10,8 @@ const PrivateToggle = ({ isPrivate, handleSetIsPrivate }: PrivateToggleProps) =>
   return (
     <button
       onClick={handleSetIsPrivate}
+      aria-label={isPrivate ? '공개로 전환' : '비공개로 전환'}
+      aria-pressed={isPrivate}
       className={cn(
         'mx-[5px] transition-all duration-250 ease-out delay-100 border border-[#d1d5da] rounded-[30px] cursor-pointer',
         'flex text-[0.5rem] justify-between items-center overflow-hidden p-2 z-[1] w-16 h-8',

--- a/src/components/SEO/SEOHead.tsx
+++ b/src/components/SEO/SEOHead.tsx
@@ -1,0 +1,43 @@
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { DEFAULT_META, getCustomMeta, SITE_NAME, SITE_URL } from 'config/constants/meta'
+
+interface SEOHeadProps {
+  title?: string
+  description?: string
+  image?: string
+  noindex?: boolean
+}
+
+const SEOHead = ({ title, description, image, noindex }: SEOHeadProps) => {
+  const { pathname, asPath } = useRouter()
+
+  const pageMeta = getCustomMeta(pathname)
+  const resolvedTitle = title || pageMeta.title || DEFAULT_META.title
+  const resolvedDescription = description || pageMeta.description || DEFAULT_META.description
+  const resolvedImage = image || pageMeta.image || DEFAULT_META.image
+  const fullImageUrl = resolvedImage?.startsWith('http') ? resolvedImage : `${SITE_URL}${resolvedImage}`
+  const canonicalUrl = `${SITE_URL}${asPath}`
+
+  return (
+    <Head>
+      <title key="title">{resolvedTitle}</title>
+      <meta key="description" name="description" content={resolvedDescription} />
+      {noindex && <meta name="robots" content="noindex,nofollow" />}
+
+      <meta key="og:title" property="og:title" content={resolvedTitle} />
+      <meta key="og:description" property="og:description" content={resolvedDescription} />
+      <meta key="og:image" property="og:image" content={fullImageUrl} />
+      <meta key="og:url" property="og:url" content={canonicalUrl} />
+      <meta key="og:type" property="og:type" content="website" />
+      <meta key="og:site_name" property="og:site_name" content={SITE_NAME} />
+
+      <meta key="twitter:card" name="twitter:card" content="summary_large_image" />
+      <meta key="twitter:title" name="twitter:title" content={resolvedTitle} />
+      <meta key="twitter:description" name="twitter:description" content={resolvedDescription} />
+      <meta key="twitter:image" name="twitter:image" content={fullImageUrl} />
+    </Head>
+  )
+}
+
+export default SEOHead

--- a/src/components/WillCard/index.tsx
+++ b/src/components/WillCard/index.tsx
@@ -32,7 +32,6 @@ const WillCard = ({ will, handleDelete, handleShare, isPrivate = true }: WillCar
     setIsOverflow((prev) => !prev)
   }, [])
 
-  console.log(will, ref?.current?.clientHeight)
   return (
     <Box position="relative">
       <Box

--- a/src/config/constants/meta.ts
+++ b/src/config/constants/meta.ts
@@ -1,5 +1,8 @@
 import { PageMeta } from './types'
 
+export const SITE_NAME = 'IIDT - IF I DIE TOMORROW'
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || ''
+
 export const DEFAULT_META: PageMeta = {
   title: 'IIDT',
   description: '만약 오늘이 마지막이라면.',
@@ -7,41 +10,38 @@ export const DEFAULT_META: PageMeta = {
 }
 
 export const getCustomMeta = (path: string): PageMeta => {
-  const basePath = path
-
-  switch (basePath) {
+  switch (path) {
+    case '/':
+      return {
+        title: 'IIDT - 만약 오늘이 마지막이라면',
+        description: '내일 죽는다면, 당신은 무엇을 남기겠습니까?',
+      }
     case '/main':
       return {
-        title: `IIDT`,
+        title: 'IIDT',
         description: '오늘 당신의 유서를 작성해주세요.',
-        image: '',
       }
     case '/will':
       return {
-        title: `오늘 유서`,
+        title: '오늘 유서',
         description: '마지막으로, 오늘 당신에게 유서를 전달합니다.',
-        image: '',
       }
     case '/about':
       return {
-        title: `오늘 유서에 대하여 `,
+        title: '오늘 유서에 대하여',
         description: '오늘 유서를 써보기로 했습니다.',
-        image: '',
       }
-
     case '/memorials':
       return {
-        title: `어느날의 기록`,
+        title: '어느날의 기록',
         description: '누군가의, 어느날의 유서. 삶을 되돌아 보세요',
-        image: '',
       }
     case '/write':
       return {
-        title: `유서 작성`,
+        title: '유서 작성',
         description: '삶을 되돌아보세요. 어땠습니까 당신의 삶은',
-        image: '',
       }
     default:
-      return null
+      return DEFAULT_META
   }
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -21,6 +21,7 @@ import { ToastContainer } from 'react-toastify'
 import ModalProvider from 'components/Common/Modal/ModalContext'
 import { Provider } from 'react-redux'
 import { ToastContextProvider } from 'contexts/Toast'
+import ErrorBoundary from 'components/Common/ErrorBoundary'
 import 'style/custom-react-toastify.css'
 import 'aos/dist/aos.css'
 const scrollMemories: { [asPath: string]: number } = {}
@@ -32,7 +33,6 @@ scrollPositionRestorer()
 
 /* 스크롤 restore  */
 function scrollPositionRestorer() {
-  console.log('scrollMemories= ', scrollMemories)
   let isPop = false
 
   if (process.browser) {
@@ -43,12 +43,10 @@ function scrollPositionRestorer() {
   }
 
   Router.events.on('routeChangeStart', () => {
-    console.log('routeChangeStart')
     saveScroll()
   })
 
   Router.events.on('routeChangeComplete', () => {
-    console.log('routeChangeComplete is pop', isPop)
     if (isPop) {
       restoreScroll()
       isPop = false
@@ -58,13 +56,11 @@ function scrollPositionRestorer() {
   })
 
   function saveScroll() {
-    console.log('save scroll ', Router.asPath, window.scrollY)
     scrollMemories[Router.asPath] = window.scrollY
   }
 
   function restoreScroll() {
     const prevScrollY = scrollMemories[Router.asPath]
-    console.log('restoreScroll ', prevScrollY)
     if (prevScrollY !== undefined) {
       window.requestAnimationFrame(() => window.scrollTo(0, prevScrollY))
     }
@@ -88,14 +84,8 @@ function MyApp(props: AppProps) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=5, minimum-scale=1, viewport-fit=cover"
         />
-        <meta name="title" content="IF I DIE TOMORROW" />
-        <meta name="description" content="만약 오늘이 마지막이라면" />
         <meta name="theme-color" content="#FFFFFF" media="(prefers-color-scheme: light)" />
         <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
-        <meta name="twitter:image" content="" />
-        <meta name="twitter:description" content="-" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="" />
         <meta name="google-site-verification" content="PTFzfhsg8i8wffMXA_9m6MPEBWiP7uHIIcXZo2_unOI" />
         <meta name="naver-site-verification" content="42db81bfd2d4d29a8e0074a206cdf9532048a969" />
 
@@ -163,27 +153,29 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
   const isFooterDisable = useFooterDisable()
 
   const body = (
-    <ToastContextProvider>
-      <ModalProvider>
-        <Layout>
-          <Menu themeMode={themeMode} toggleTheme={toggleTheme} />
-          <div style={{ minHeight: `calc(100vh - ${MENU_HEIGHT}px - ${FOOTER_HEIGHT}px)` }}>
-            <Component {...pageProps} />
-          </div>
-        </Layout>
-        {!isFooterDisable && <Footer />}
+    <ErrorBoundary>
+      <ToastContextProvider>
+        <ModalProvider>
+          <Layout>
+            <Menu themeMode={themeMode} toggleTheme={toggleTheme} />
+            <main style={{ minHeight: `calc(100vh - ${MENU_HEIGHT}px - ${FOOTER_HEIGHT}px)` }}>
+              <Component {...pageProps} />
+            </main>
+          </Layout>
+          {!isFooterDisable && <Footer />}
 
-        <ToastContainer
-          position="bottom-right"
-          autoClose={3000}
-          closeOnClick
-          draggable={false}
-          pauseOnHover={false}
-          pauseOnFocusLoss={false}
-          hideProgressBar={true}
-        />
-      </ModalProvider>
-    </ToastContextProvider>
+          <ToastContainer
+            position="bottom-right"
+            autoClose={3000}
+            closeOnClick
+            draggable={false}
+            pauseOnHover={false}
+            pauseOnFocusLoss={false}
+            hideProgressBar={true}
+          />
+        </ModalProvider>
+      </ToastContextProvider>
+    </ErrorBoundary>
   )
 
   if (!mounted) {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,7 +4,7 @@ import Script from 'next/script'
 class MyDocument extends Document {
   render() {
     return (
-      <Html translate="no">
+      <Html lang="ko" translate="no">
         <Head>
           <link rel="shortcut icon" href="/favicon.ico" />
           <link rel="apple-touch-icon" href="/logo.png" />

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,7 +1,13 @@
 import About from '@views/About'
+import SEOHead from 'components/SEO/SEOHead'
 
 const AboutPage = () => {
-  return <About />
+  return (
+    <>
+      <SEOHead />
+      <About />
+    </>
+  )
 }
 
 export default AboutPage

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,16 @@
 import dynamic from 'next/dynamic'
+import SEOHead from 'components/SEO/SEOHead'
 const Home = dynamic(import('views/Home'))
 
 // import { withAuthComponent, withAuthServerSideProps } from 'hoc/withAuthServerSide'
 
 const IndexPage = () => {
-  return <Home />
+  return (
+    <>
+      <SEOHead />
+      <Home />
+    </>
+  )
 }
 
 export default IndexPage

--- a/src/pages/onboarding.tsx
+++ b/src/pages/onboarding.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router'
 import { useCheckNickname } from '@/queries/auth'
 import { Flex, Box, Text } from 'components/Common'
 import { Button } from 'components/Common/Button'
+import SEOHead from 'components/SEO/SEOHead'
 
 export default function OnboardingPage() {
   const { data: session, update } = useSession()
@@ -76,12 +77,16 @@ export default function OnboardingPage() {
   const showRegisterButton = isValid && !isDuplicate && isFetched && checkResult
 
   return (
+    <>
+    <SEOHead noindex />
     <Flex className="min-h-screen items-center justify-center flex-col p-5">
       <Text fontSize="24px" mb="8px">
         마지막으로...
       </Text>
+      <label htmlFor="nickname-input" className="sr-only">닉네임</label>
       <Text textAlign="center">닉네임을 결정해주세요</Text>
       <input
+        id="nickname-input"
         className="outline-none border border-current my-8 resize-none w-full max-w-[320px] text-lg font-normal font-[Nanum_Myeongjo] p-2 text-[var(--color-text-secondary)] leading-7 bg-inherit placeholder:text-center placeholder:text-grayscale-5"
         value={nickname}
         onChange={handleChange}
@@ -91,7 +96,7 @@ export default function OnboardingPage() {
 
       {isDuplicate && isFetched && (
         <Box mb="16px">
-          <Text color="red">아쉽지만 다른 닉네임을 사용해주세요.</Text>
+          <Text color="red" role="alert">아쉽지만 다른 닉네임을 사용해주세요.</Text>
         </Box>
       )}
 
@@ -105,5 +110,6 @@ export default function OnboardingPage() {
         </Button>
       )}
     </Flex>
+    </>
   )
 }

--- a/src/queries/will/mutations/use-create-will.ts
+++ b/src/queries/will/mutations/use-create-will.ts
@@ -26,8 +26,7 @@ export function useCreateWill({ onSuccessCallback }: UseCreateWillOptions = {}) 
 
       onSuccessCallback?.()
     },
-    onError: (error) => {
-      console.error('Failed to create will:', error)
+    onError: () => {
       onToast({
         type: 'error',
         message: '작성에 실패했습니다',

--- a/src/queries/will/mutations/use-delete-will.ts
+++ b/src/queries/will/mutations/use-delete-will.ts
@@ -25,8 +25,7 @@ export function useDeleteWill({ onSuccessCallback }: UseDeleteWillOptions = {}) 
 
       onSuccessCallback?.()
     },
-    onError: (error) => {
-      console.error('Failed to delete will:', error)
+    onError: () => {
       onToast({
         type: 'error',
         message: '삭제에 실패했습니다',

--- a/src/queries/will/mutations/use-update-will.ts
+++ b/src/queries/will/mutations/use-update-will.ts
@@ -27,8 +27,7 @@ export function useUpdateWill({ onSuccessCallback }: UseUpdateWillOptions = {}) 
 
       onSuccessCallback?.()
     },
-    onError: (error) => {
-      console.error('Failed to update will:', error)
+    onError: () => {
       onToast({
         type: 'error',
         message: '수정에 실패했습니다',

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -65,7 +65,7 @@ const Home: React.FC = () => {
           title="내일이 내생에"
           secondTitle="마지막이라고 생각해보신적 있나요?"
           imagePath="/images/home/patrick-ryan-3kUIaB2EPp8-unsplash.jpg"
-          alt=""
+          alt="내일이 마지막이라면 - 석양 풍경"
         />
         <Box mb={'100px'} />
         <MainCard
@@ -73,7 +73,7 @@ const Home: React.FC = () => {
           title=" 만약 내일 생을 마감한다면,"
           secondTitle="소중한 이들에게 하고싶은 말이 있나요?"
           imagePath="/images/home/huyen-pham--PTlx55R-KU-unsplash.jpg"
-          alt=""
+          alt="소중한 이들에게 전하는 마지막 메시지"
         />
 
         <Box mb="50px" className="text-center" height="100vh">

--- a/src/views/Main/components/modal/ShareModal.tsx
+++ b/src/views/Main/components/modal/ShareModal.tsx
@@ -76,7 +76,7 @@ const ShareModal = ({ onDismiss, content, willId, title, ...props }: any) => {
           <Flex justifyContent="center" alignItems="center" flexWrap="wrap" className="gap-2.5">
             <CopyToClipboard toCopy={`${API_URL}/will/${willId}`} />
             <div onClick={handleKakao} type="button">
-              <img alt="" src="//developers.kakao.com/assets/img/about/logos/kakaolink/kakaolink_btn_small.png" />
+              <img alt="카카오톡으로 공유하기" src="//developers.kakao.com/assets/img/about/logos/kakaolink/kakaolink_btn_small.png" />
             </div>
           </Flex>
           <div></div>

--- a/src/views/Main/components/modal/WriteDeleteModal.tsx
+++ b/src/views/Main/components/modal/WriteDeleteModal.tsx
@@ -4,9 +4,9 @@ import { Flex, Box, Text } from 'components/Common'
 const ConfirmButton = ({
   background,
   ...props
-}: React.HTMLAttributes<HTMLDivElement> & { background?: string }) => (
-  <div
-    className="flex flex-row justify-center items-center py-3.5 px-4 gap-2.5 w-[195px] h-[50px] rounded cursor-pointer flex-none grow text-white"
+}: React.ButtonHTMLAttributes<HTMLButtonElement> & { background?: string }) => (
+  <button
+    className="flex flex-row justify-center items-center py-3.5 px-4 gap-2.5 w-[195px] h-[50px] rounded cursor-pointer flex-none grow text-white border-none"
     style={{ background: background || '#000' }}
     {...props}
   />

--- a/src/views/Memorials/components/modal/ShareModal.tsx
+++ b/src/views/Memorials/components/modal/ShareModal.tsx
@@ -76,7 +76,7 @@ const ShareModal = ({ onDismiss, content, willId, title, ...props }: any) => {
           <Flex justifyContent="center" alignItems="center" flexWrap="wrap" className="gap-2.5">
             <CopyToClipboard toCopy={`${API_URL}/will/${willId}`} />
             <div onClick={handleKakao}>
-              <img alt="" src="//developers.kakao.com/assets/img/about/logos/kakaolink/kakaolink_btn_small.png" />
+              <img alt="카카오톡으로 공유하기" src="//developers.kakao.com/assets/img/about/logos/kakaolink/kakaolink_btn_small.png" />
             </div>
           </Flex>
           <div></div>

--- a/src/views/Memorials/components/modal/WriteDeleteModal.tsx
+++ b/src/views/Memorials/components/modal/WriteDeleteModal.tsx
@@ -4,9 +4,9 @@ import { Flex, Box, Text } from 'components/Common'
 const ConfirmButton = ({
   background,
   ...props
-}: React.HTMLAttributes<HTMLDivElement> & { background?: string }) => (
-  <div
-    className="flex flex-row justify-center items-center py-3.5 px-4 gap-2.5 w-[195px] h-[50px] rounded cursor-pointer flex-none grow text-white"
+}: React.ButtonHTMLAttributes<HTMLButtonElement> & { background?: string }) => (
+  <button
+    className="flex flex-row justify-center items-center py-3.5 px-4 gap-2.5 w-[195px] h-[50px] rounded cursor-pointer flex-none grow text-white border-none"
     style={{ background: background || '#000' }}
     {...props}
   />

--- a/src/views/NotFound.tsx
+++ b/src/views/NotFound.tsx
@@ -1,9 +1,12 @@
 import { Text, Box } from 'components/Common'
 import Link from 'next/link'
 import { MainButton } from 'views/Home'
+import SEOHead from 'components/SEO/SEOHead'
 
 const NotFound = () => {
   return (
+    <>
+    <SEOHead title="페이지를 찾을 수 없습니다" noindex />
     <Box className="min-h-[calc(100vh-64px)] flex justify-center items-center">
       <Box
         className="w-full min-h-[calc(100vh-64px)] absolute -z-[1]"
@@ -33,6 +36,7 @@ const NotFound = () => {
         </Link>
       </div>
     </Box>
+    </>
   )
 }
 


### PR DESCRIPTION
## 요약
- 프로덕션 코드 품질 개선: console.log 11개 제거, ErrorBoundary 추가, 배열 인덱스 키 수정
- SEO 개선: SEOHead 컴포넌트로 페이지별 동적 OG/Twitter 메타 태그, 빈 alt 속성 수정
- 접근성 개선: lang="ko", role="dialog", aria-label, 시맨틱 HTML (main, footer, button)

## 변경 내용

### 코드 품질
- `_app.tsx`, `WillCard`, `Menu`, `MenuWrapper`, mutation hooks에서 console.log/error 제거
- `ErrorBoundary` 컴포넌트 신규 생성 → 런타임 에러 시 폴백 UI
- `DropdownMenu.tsx` 배열 인덱스 키 → label+href 키로 수정

### SEO
- `SEOHead` 컴포넌트 신규 생성 (동적 og:title/description/image, twitter:card)
- `Page.tsx`의 `PageMeta` → `SEOHead`로 교체 (og:title undefined 버그 수정)
- `_app.tsx`에서 빈 Twitter 메타 태그 제거
- `meta.ts` 보강: SITE_NAME/URL 상수, 홈 경로 추가, null 반환 제거
- 빈 alt="" 속성 4개 수정

### 접근성
- `_document.tsx`: `lang="ko"` 추가
- 모달: `role="dialog"`, `aria-modal="true"` 추가
- 메뉴 버튼: `<Box onClick>` → `<button aria-label="메뉴 열기" aria-expanded>` 
- `_app.tsx`: 콘텐츠 래퍼 `<div>` → `<main>` 태그
- `Footer`: `<Box>` → `<footer>`, `<Text onClick>` → `<a>` 링크
- `ThemeToggleButton`, `PrivateToggle`: aria-label/aria-pressed 추가
- `WriteDeleteModal` (Main/Memorials): ConfirmButton `<div>` → `<button>`
- `Button`: focus-visible 포커스 인디케이터 추가
- 온보딩: `<label>` + `role="alert"` 추가

## 테스트 방법
- [ ] `yarn build` 빌드 성공 확인
- [ ] 브라우저 DevTools에서 각 페이지 `<head>` 메타 태그 확인
- [ ] 콘솔에 불필요한 console.log 출력 없는지 확인
- [ ] Tab 키로 포커스 이동 시 인디케이터 표시 확인
- [ ] 모달 열기 → role="dialog" 확인
- [ ] Lighthouse 접근성 점수 측정

## 참고
- [PR 기록](docs/pr/2026-03-08-seo-code-quality-a11y.md)
- `NEXT_PUBLIC_SITE_URL` 환경변수 설정 필요 (OG 메타 태그 절대 경로용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
