### PR TITLE
docs: README를 Hook-Prove-Enable-Extend 구조로 재작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,34 @@
-# IIDT - Kolkata v1
+# IIDT
 
-디지털 유언장 서비스의 프론트엔드 애플리케이션입니다.
+디지털 유언장 서비스의 프론트엔드 애플리케이션
 
-## Tech Stack
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white) ![Next.js](https://img.shields.io/badge/Next.js_16-000000?logo=nextdotjs) ![License](https://img.shields.io/badge/License-GPL--3.0-blue)
 
-| Category | Technology |
-|---|---|
-| Framework | Next.js 16, React 19 |
-| Language | TypeScript |
-| Styling | Tailwind CSS 4 |
-| State Management | Redux Toolkit, React Query |
-| UI Components | shadcn/ui, Radix UI |
-| Authentication | NextAuth (Auth.js v5) - Google, Kakao, Naver |
-| Database | Supabase (PostgreSQL) - 직접 연결 |
-| Deployment | AWS CodeDeploy |
+## Quick Start
 
-## Getting Started
-
-### Prerequisites
-
-- Node.js 18+
-- Yarn
-
-### Installation
-
-```sh
+```bash
+# 설치
 yarn
-```
 
-### Development
-
-```sh
+# 개발 서버 실행
 yarn dev
-# http://localhost:5194
+# → http://localhost:5194
 ```
 
-### Production Build
+> **참고:** `.env.local.example`을 참고하여 `.env.local` 파일을 생성해야 합니다.
 
-```sh
-yarn build
-yarn start
-# http://localhost:6060
-```
+## Features
+
+- **디지털 유언장 작성** — 비회원도 유언장을 작성할 수 있는 접근성 높은 서비스
+- **소셜 로그인 3종 지원** — Google, Kakao, Naver OAuth를 NextAuth v5로 통합
+- **하이브리드 라우팅** — Pages Router(페이지)와 App Router(API)를 목적에 맞게 분리
+- **다크/라이트 모드** — CSS 커스텀 속성 기반 테마 전환
+- **SEO 최적화** — next-sitemap을 활용한 자동 사이트맵 생성
 
 ## Scripts
 
 | Command | Description |
-|---|---|
+|---------|-------------|
 | `yarn dev` | 개발 서버 실행 (port 5194) |
 | `yarn build` | 프로덕션 빌드 |
 | `yarn start` | 프로덕션 서버 실행 (port 6060) |
@@ -55,17 +37,23 @@ yarn start
 | `yarn format:write` | Prettier 포맷 자동 수정 |
 | `yarn analyze` | 번들 분석 |
 
-## Project Structure
+## Architecture
 
-```
+- **Routing**: Pages Router(페이지) + App Router(API 전용) 하이브리드 구조
+- **Authentication**: NextAuth (Auth.js v5) — 소셜 OAuth, JWT 세션 (httpOnly cookie)
+- **Database**: Next.js API Route에서 `@supabase/supabase-js`로 Supabase 직접 쿼리
+- **State**: Redux Toolkit (navi), React Query (서버 상태), Zustand
+- **Styling**: Tailwind CSS 4 + shadcn/ui + Radix UI
+- **Theming**: CSS 커스텀 속성 기반 다크/라이트 모드
+
+```text
 src/
 ├── app/api/           # API 라우트 (NextAuth, will CRUD)
 ├── api/               # 클라이언트 API 호출
 ├── components/
-│   ├── Common/        # 공통 컴포넌트 (Box, Button, Card, Modal 등)
+│   ├── Common/        # 공통 컴포넌트
 │   ├── Layout/        # 레이아웃 컴포넌트
-│   ├── ui/            # shadcn/ui 컴포넌트
-│   └── ...
+│   └── ui/            # shadcn/ui 컴포넌트
 ├── config/            # 설정 및 상수
 ├── contexts/          # React Context
 ├── hooks/             # 커스텀 훅
@@ -74,18 +62,42 @@ src/
 ├── queries/           # React Query 설정
 ├── services/          # 서비스 레이어 (will)
 ├── store/             # Redux 스토어 (navi)
-├── style/             # 글로벌 스타일 (CSS 커스텀 속성 기반 테마)
+├── style/             # 글로벌 스타일
 ├── types/             # TypeScript 타입 정의
 ├── utils/             # 유틸리티 함수
 └── views/             # 페이지 뷰 컴포넌트
 ```
+
+## Tech Stack
+
+| Category | Technology |
+|----------|------------|
+| Framework | Next.js 16, React 19 |
+| Language | TypeScript |
+| Styling | Tailwind CSS 4 |
+| State Management | Redux Toolkit, React Query, Zustand |
+| UI Components | shadcn/ui, Radix UI |
+| Authentication | NextAuth (Auth.js v5) — Google, Kakao, Naver |
+| Database | Supabase (PostgreSQL) |
+| Deployment | AWS CodeDeploy |
+
+## Environment Variables
+
+`.env.local.example` 참고. 필수 환경변수:
+
+- `NEXTAUTH_URL` / `NEXTAUTH_SECRET` — NextAuth 설정
+- `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` — Google OAuth
+- `AUTH_KAKAO_ID` / `AUTH_KAKAO_SECRET` — Kakao OAuth
+- `AUTH_NAVER_ID` / `AUTH_NAVER_SECRET` — Naver OAuth
+- `NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` — Supabase 연결
+- `NEXT_PUBLIC_SITE_URL` — 사이트 URL (OG 메타 태그용)
 
 ## Path Aliases
 
 `tsconfig.json`에 정의된 경로 별칭:
 
 | Alias | Path |
-|---|---|
+|-------|------|
 | `@/*` | `src/*` |
 | `@components/*` | `src/components/*` |
 | `@hooks/*` | `src/hooks/*` |
@@ -97,27 +109,26 @@ src/
 | `@lib/*` | `src/lib/*` |
 | `@public/*` | `public/*` |
 
-## Architecture
+## Contributing
 
-- **Routing**: Pages Router(페이지) + App Router(API 전용) 하이브리드 구조
-- **Authentication**: NextAuth (Auth.js v5) - 소셜 OAuth 로그인, JWT 세션 (httpOnly cookie)
-- **Database**: Next.js API Route에서 `@supabase/supabase-js`로 Supabase 직접 쿼리
-- **Theming**: CSS 커스텀 속성 기반 다크/라이트 모드 지원
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'feat: add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
 
-## Environment Variables
+## Reporting Issues
 
-`.env.local.example` 참고. 필수 환경변수:
+Found a bug or have a suggestion? [Open an issue](https://github.com/IIDT-CREW/IIDT-front-end/issues).
 
-- `NEXTAUTH_URL` / `NEXTAUTH_SECRET` - NextAuth 설정
-- `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` - Google OAuth
-- `AUTH_KAKAO_ID` / `AUTH_KAKAO_SECRET` - Kakao OAuth
-- `AUTH_NAVER_ID` / `AUTH_NAVER_SECRET` - Naver OAuth
-- `NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` - Supabase 연결
-- `NEXT_PUBLIC_SITE_URL` - 사이트 URL (OG 메타 태그용)
+## License
+
+This project is licensed under the GPL-3.0 License. See [LICENSE](./LICENSE) for details.
 
 ## PR 기록
 
 | 날짜 | 주제 | 문서 |
 |------|------|------|
+| 2026-04-08 | README 생성 | [docs/pr/2026-04-08-readme-gen.md](docs/pr/2026-04-08-readme-gen.md) |
 | 2026-03-09 | 비회원 글쓰기 기능 | [docs/pr/2026-03-09-guest-write.md](docs/pr/2026-03-09-guest-write.md) |
 | 2026-03-08 | SEO, 코드 품질, 접근성 개선 | [docs/pr/2026-03-08-seo-code-quality-a11y.md](docs/pr/2026-03-08-seo-code-quality-a11y.md) |

--- a/docs/pr/2026-04-08-readme-gen.md
+++ b/docs/pr/2026-04-08-readme-gen.md
@@ -1,0 +1,47 @@
+# PR 기록: README 생성
+
+- 날짜: 2026-04-08
+- 브랜치: westkite1201/IIDT-front-end/gen-readme
+- 변경 파일 수: 1
+- 요약:
+  - 기존 README.md를 Hook-Prove-Enable-Extend 구조로 전면 재작성
+  - Quick Start를 최상단으로 이동하여 온보딩 경험 개선
+  - Features 섹션 신규 추가 (사용 사례 중심 5개 항목)
+  - TypeScript, Next.js, GPL-3.0 배지 추가
+  - Contributing, Issue Reporting 섹션 추가
+  - 기존 PR 기록 섹션 보존
+
+## 진행상황 (Done)
+
+- [x] 기존 README 백업 (README.md.bak)
+- [x] 레포 분석 (언어, 프레임워크, LOC, 디렉토리 구조 등)
+- [x] 새 README 생성 (배지, Quick Start, Features, Architecture, Tech Stack 등)
+- [x] 사용자 관리 섹션(PR 기록) 보존
+
+## 할 일 (Next)
+
+- [ ] PR 머지 후 main 브랜치 반영 확인
+- [ ] 향후 CHANGELOG.md 도입 검토
+- [ ] CONTRIBUTING.md 별도 파일 분리 검토
+
+## 우리가 검토한 것 / 결정 사항
+
+- README를 한국어 기반으로 유지 (프로젝트 팀 언어에 맞춤)
+- Quick Start에 env 설정 안내를 포함하되, 실제 값은 노출하지 않음
+- Metrics 섹션은 테스트 파일이 1개뿐이라 생략 (허영 지표 방지)
+
+## 참고 아티클 / 레퍼런스
+
+- 없음
+
+## research.md 업데이트
+
+- 상태: NO
+- 근거:
+  - README.md만 변경된 단순 문서 작업
+- 액션:
+  - [x] 생략
+
+## 변경 파일(참고)
+
+- README.md (65 insertions, 55 deletions)


### PR DESCRIPTION
## 요약
- 기존 README.md를 Hook-Prove-Enable-Extend 서사 구조로 전면 재작성
- Quick Start를 최상단으로 이동하여 온보딩 경험 개선
- Features, Contributing, Issue Reporting 섹션 신규 추가

## 변경 내용
- **Hero**: 프로젝트 설명 + TypeScript/Next.js/GPL-3.0 배지 추가
- **Quick Start**: `yarn` → `yarn dev` 2단계로 간소화, env 설정 안내 포함
- **Features**: 사용 사례 중심 5개 핵심 기능 정리
- **Architecture**: 하이브리드 라우팅, 인증, DB, 상태 관리, 스타일링 개요 + 디렉토리 트리
- **Tech Stack**: 카테고리별 기술 스택 테이블
- **Contributing / Issue Reporting**: 기여 가이드 및 GitHub Issues 링크
- 기존 PR 기록 섹션 보존

## 테스트 방법
- [ ] README.md 렌더링 확인 (GitHub에서 미리보기)
- [ ] 내부 링크(`LICENSE`, `docs/pr/*`) 정상 동작 확인
- [ ] Quick Start 명령어 실제 실행 가능 여부 확인

## 참고
- [docs/pr/2026-04-08-readme-gen.md](docs/pr/2026-04-08-readme-gen.md)

## 문서 업데이트 체크리스트
- [x] README.md 재작성
- [x] docs/pr 기록 추가
