### PR TITLE
Continue parity restoration for onboarding, not-found, and will detail

### DIFF
--- a/src/app/onboarding/onboarding.module.css
+++ b/src/app/onboarding/onboarding.module.css
@@ -1,0 +1,48 @@
+.container {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.title {
+  margin-bottom: 8px;
+  font-size: 24px;
+  line-height: 1.5;
+}
+
+.subtitle {
+  text-align: center;
+  line-height: 1.5;
+}
+
+.input {
+  width: 100%;
+  max-width: 320px;
+  margin: 32px 0;
+  padding: 8px;
+  border: 1px solid currentColor;
+  outline: none;
+  resize: none;
+  background: inherit;
+  color: var(--color-text-secondary);
+  font-family: 'Nanum Myeongjo', serif;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 28px;
+}
+
+.input::placeholder {
+  text-align: center;
+  color: var(--color-grayscale-5);
+}
+
+.errorWrap {
+  margin-bottom: 16px;
+}
+
+.errorText {
+  color: #ef4444;
+}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react'
 import { useCheckNickname } from '@/queries/auth'
 import { Button } from 'components/ui/button'
 import { useReplaceNavigate } from '@/hooks/useCurrentPath'
+import styles from './onboarding.module.css'
 
 export default function OnboardingPage() {
   const { data: session, update } = useSession()
@@ -77,15 +78,15 @@ export default function OnboardingPage() {
   const showRegisterButton = isValid && !isDuplicate && isFetched && checkResult
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-5">
-      <p className="mb-2 text-[24px] leading-relaxed">마지막으로...</p>
+    <div className={styles.container}>
+      <p className={styles.title}>마지막으로...</p>
       <label htmlFor="nickname-input" className="sr-only">
         닉네임
       </label>
-      <p className="text-center leading-relaxed">닉네임을 결정해주세요</p>
+      <p className={styles.subtitle}>닉네임을 결정해주세요</p>
       <input
         id="nickname-input"
-        className="outline-none border border-current my-8 resize-none w-full max-w-[320px] text-lg font-normal font-[Nanum_Myeongjo] p-2 text-[var(--color-text-secondary)] leading-7 bg-inherit placeholder:text-center placeholder:text-grayscale-5"
+        className={styles.input}
         value={nickname}
         onChange={handleChange}
         placeholder="닉네임"
@@ -93,8 +94,8 @@ export default function OnboardingPage() {
       />
 
       {isDuplicate && isFetched && (
-        <div className="mb-4">
-          <p className="text-red-500" role="alert">
+        <div className={styles.errorWrap}>
+          <p className={styles.errorText} role="alert">
             아쉽지만 다른 닉네임을 사용해주세요.
           </p>
         </div>

--- a/src/views/NotFound.tsx
+++ b/src/views/NotFound.tsx
@@ -1,25 +1,20 @@
 import Link from 'next/link'
+import styles from './notfound.module.css'
 
 const NotFound = () => {
   return (
-    <div className="relative flex min-h-[calc(100vh_-_64px)] items-center justify-center">
-      <div
-        className="absolute -z-[1] min-h-[calc(100vh_-_64px)] w-full"
-        style={{
-          background:
-            'linear-gradient(0deg, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.6)), url(/images/home/joshua-sortino-XMcoTHgNcQA-unsplash.jpg)',
-        }}
-      />
-      <div className="flex flex-col items-center justify-center">
-        <p className="mb-[18px] text-[36px] leading-relaxed">길을 잃으셨나요?</p>
-        <p className="font-[SUIT] leading-relaxed"> 괜찮아요. 저희가 안내할게요.</p>
-        <p className="font-[SUIT] leading-relaxed"> 찾으시는 페이지의 주소가 잘못 입력되었거나,</p>
-        <p className="mb-[18px] font-[SUIT] leading-relaxed">주소의 변경 혹은 삭제로 인해 사용하실수 없습니다.</p>
+    <div className={styles.container}>
+      <div className={styles.background} />
+      <div className={styles.inner}>
+        <p className={styles.title}>길을 잃으셨나요?</p>
+        <p className={styles.text}> 괜찮아요. 저희가 안내할게요.</p>
+        <p className={styles.text}> 찾으시는 페이지의 주소가 잘못 입력되었거나,</p>
+        <p className={`${styles.text} ${styles.textGap}`}>주소의 변경 혹은 삭제로 인해 사용하실수 없습니다.</p>
 
-        <p className="font-[SUIT] leading-relaxed">
+        <p className={styles.text}>
           입력하신 페이지의 주소가 정확한지 다시 한 번 획인해주시고, 같은 문제가 또 발생한다면
         </p>
-        <p className="mb-[18px] font-[SUIT] leading-relaxed">ifteam@gmail.com으로 알려주세요.</p>
+        <p className={`${styles.text} ${styles.textGap}`}>ifteam@gmail.com으로 알려주세요.</p>
         <Link
           href="/"
           className="flex h-[50px] w-[335px] items-center justify-center rounded-[4px] bg-[var(--color-contrast)] px-4 py-[14px] font-[SUIT] text-[13.3333px] text-[var(--color-bg)] no-underline sm:h-[44px]"

--- a/src/views/Will/components/TitleBanner.tsx
+++ b/src/views/Will/components/TitleBanner.tsx
@@ -3,6 +3,7 @@ import moment from 'moment'
 import StyledImage from 'components/Common/Image/StyledImage'
 import Typing from 'views/Home/components/Typing'
 import cn from 'utils/cn'
+import styles from '../will.module.css'
 
 type TitleBannerProps = {
   height: string
@@ -18,8 +19,8 @@ const TitleBanner = ({ height, title, date, imagePath }: TitleBannerProps) => {
   }, [])
 
   return (
-    <div>
-      <div className="relative w-full" style={{ height }}>
+    <div className={styles.titleBannerWrap}>
+      <div style={{ height }}>
         <StyledImage
           isFill
           src={imagePath}
@@ -27,19 +28,14 @@ const TitleBanner = ({ height, title, date, imagePath }: TitleBannerProps) => {
           position="fixed"
           className="absolute w-full h-full -z-[1] object-cover bg-[linear-gradient(0deg,rgba(255,255,255,0.2),rgba(255,255,255,0.2))] [clip-path:inset(0)]"
         />
-        <div className="relative h-full w-full">
-          <div className="relative flex h-full flex-col items-center justify-center">
-            <div className="dark:px-2.5 text-[18px] lg:text-[32px] font-semibold bg-black text-white w-4/5 text-center leading-normal">
+        <div className={styles.titleBannerInner}>
+          <div className={styles.titleBannerContent}>
+            <div className={styles.titleText}>
               <span className="text-white">
                 <Typing str={title ?? ''} handleStatus={handleStatus} status={status} />
               </span>
             </div>
-            <div
-              className={cn(
-                'dark:px-2.5 text-[14px] lg:text-[18px] font-semibold text-white transition-all duration-1000 leading-normal',
-                status === 'is_done' ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-[15px]',
-              )}
-            >
+            <div className={cn(styles.dateText, status === 'is_done' && styles.dateTextVisible)}>
               {date ? moment(date).format('YYYY년 MM월 DD일 hh시 mm분') : ''}
             </div>
           </div>

--- a/src/views/Will/components/WillShareCard.tsx
+++ b/src/views/Will/components/WillShareCard.tsx
@@ -2,6 +2,7 @@ import { Card } from 'components/ui/card'
 import { Will } from '@api/will/types'
 import { QUESTION_LIST } from '@views/Write/data'
 import { IS_DEFAULT_MODE } from 'config/constants/default'
+import styles from '../will.module.css'
 
 type WillCardProps = {
   will?: Will
@@ -16,21 +17,17 @@ const WillCard = ({ will, isDisplayHeader = true }: WillCardProps) => {
   const isDefaultType = contentType === IS_DEFAULT_MODE
 
   return (
-    <Card
-      className="box mb-10 min-w-[362px] max-w-[582px] rounded-[4px] bg-[var(--color-bg)] px-5 py-5"
-      data-aos="fade"
-      data-aos-duration="2500"
-    >
+    <Card className={styles.card} data-aos="fade" data-aos-duration="2500">
       {isDisplayHeader && (
-        <div className="h-[25px] bg-[var(--color-contrast)] shadow-[0_-1px_4px_rgb(0_0_0/70%)]">
-          <p className="text-center text-lg text-white">마지막으로...</p>
+        <div className={styles.cardHeader}>
+          <p className={styles.cardHeaderText}>마지막으로...</p>
         </div>
       )}
-      <div className="mt-10">
+      <div className={styles.cardBody}>
         {isDefaultType ? (
-          <pre className="whitespace-break-spaces p-5 text-lg leading-[1.5] text-[var(--color-text)]">{content}</pre>
+          <pre className={styles.cardContents}>{content}</pre>
         ) : (
-          <div className="space-y-4 p-5 text-lg leading-[1.5] text-[var(--color-text)]">
+          <div className={styles.cardContents}>
             {answerList?.map((answer, index) => (
               <div key={`share-answer-${index}`}>
                 <p className="font-semibold">{QUESTION_LIST[parseInt(answer?.question_index)]?.question}</p>
@@ -40,8 +37,8 @@ const WillCard = ({ will, isDisplayHeader = true }: WillCardProps) => {
           </div>
         )}
       </div>
-      <div className="mt-[18px] flex justify-end">
-        <p className="text-[var(--color-grayscale-5)]">{memNickname ? memNickname : '익명'} 마침.</p>
+      <div className={styles.cardAuthorRow}>
+        <p className={styles.cardAuthor}>{memNickname ? memNickname : '익명'} 마침.</p>
       </div>
     </Card>
   )

--- a/src/views/Will/index.tsx
+++ b/src/views/Will/index.tsx
@@ -9,6 +9,7 @@ import TitleBanner from '@views/Will/components/TitleBanner'
 import { MainButton } from '@views/Home'
 import type { Will } from '@api/will/types'
 import { useNavigate, useRouteParam } from '@/hooks/useCurrentPath'
+import styles from './will.module.css'
 
 type WillTitleProps = {
   data?: Will
@@ -16,7 +17,7 @@ type WillTitleProps = {
 
 const WillTitle = ({ data }: WillTitleProps) => {
   return (
-    <div className="mb-9">
+    <div className={styles.titleWrap}>
       <TitleBanner
         height="100vh"
         title={data?.TITLE}
@@ -33,8 +34,8 @@ type WillContentProps = {
 }
 const WillContent = ({ isLoading, data }: WillContentProps) => {
   return (
-    <div className="flex flex-col items-center justify-center">
-      <div className="flex flex-col items-center justify-center">{!isLoading && data && <WillCard will={data} />}</div>
+    <div className={styles.contentOuter}>
+      <div className={styles.contentInner}>{!isLoading && data && <WillCard will={data} />}</div>
     </div>
   )
 }
@@ -43,17 +44,17 @@ type WillFooterProps = {
 }
 const WillFooter = ({ handleWrite }: WillFooterProps) => {
   return (
-    <div className="my-[50px]">
-      <div className="flex flex-col items-center justify-center">
-        <div className="flex flex-col items-center justify-center">
-          <p className="font-semibold leading-relaxed" data-aos="fade-up" data-aos-duration="1000">
+    <div className={styles.footer}>
+      <div className={styles.footerInner}>
+        <div className={styles.footerTextWrap}>
+          <p className={styles.footerText} data-aos="fade-up" data-aos-duration="1000">
             한번 하루 유서를 적어보시겠어요?
           </p>
-          <p className="font-semibold leading-relaxed" data-aos="fade-up" data-aos-duration="1500">
+          <p className={styles.footerText} data-aos="fade-up" data-aos-duration="1500">
             좋은 경험이 될거에요.
           </p>
         </div>
-        <div className="mt-[30px]" data-aos="fade" data-aos-duration="3000">
+        <div className={styles.footerButtonWrap} data-aos="fade" data-aos-duration="3000">
           <MainButton onClick={handleWrite}>네. 작성해보겠습니다.</MainButton>
         </div>
       </div>
@@ -80,7 +81,7 @@ const WillPage = () => {
 
   return (
     <Page title={data?.TITLE} content={data?.CONTENT} isFullPage>
-      <div className="min-h-[calc(100%_-_231px)]">
+      <div className={styles.container}>
         <WillTitle data={data} />
         <WillContent data={data} isLoading={isLoading} />
         <WillFooter handleWrite={handleWrite} />

--- a/src/views/Will/will.module.css
+++ b/src/views/Will/will.module.css
@@ -1,0 +1,152 @@
+.container {
+  min-height: calc(100% - 231px);
+}
+
+.titleWrap {
+  margin-bottom: 36px;
+}
+
+.contentOuter {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.contentInner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.footer {
+  margin-top: 50px;
+  margin-bottom: 50px;
+}
+
+.footerInner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.footerTextWrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.footerText {
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.footerButtonWrap {
+  margin-top: 30px;
+}
+
+.card {
+  min-width: 362px;
+  max-width: 582px;
+  margin-bottom: 40px;
+  padding: 20px;
+  border-radius: 4px;
+  background: var(--color-bg);
+}
+
+.cardHeader {
+  height: 25px;
+  background: var(--color-contrast);
+  box-shadow: 0 -1px 4px rgb(0 0 0 / 70%);
+}
+
+.cardHeaderText {
+  color: #fff;
+  font-size: 18px;
+  text-align: center;
+}
+
+.cardBody {
+  margin-top: 40px;
+}
+
+.cardContents {
+  white-space: break-spaces;
+  font-weight: 400;
+  line-height: 1.5;
+  font-size: 18px;
+  padding: 20px;
+  color: var(--color-text);
+}
+
+.cardAuthorRow {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 18px;
+}
+
+.cardAuthor {
+  color: var(--color-grayscale-5);
+}
+
+.titleBannerWrap {
+  position: relative;
+  width: 100%;
+}
+
+.titleBannerInner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.titleBannerContent {
+  position: relative;
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.titleText {
+  width: 80%;
+  text-align: center;
+  background: #000;
+  color: #fff;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: normal;
+}
+
+.titleText span {
+  color: #fff;
+}
+
+.dateText {
+  color: #fff;
+  opacity: 0;
+  transition: all 1s;
+  transform: translate3d(0, 15px, 0);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: normal;
+}
+
+.dateTextVisible {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+@media (min-width: 968px) {
+  .titleText {
+    font-size: 32px;
+  }
+
+  .dateText {
+    font-size: 18px;
+  }
+}

--- a/src/views/notfound.module.css
+++ b/src/views/notfound.module.css
@@ -1,0 +1,38 @@
+.container {
+  position: relative;
+  display: flex;
+  min-height: calc(100vh - 64px);
+  align-items: center;
+  justify-content: center;
+}
+
+.background {
+  position: absolute;
+  z-index: -1;
+  width: 100%;
+  min-height: calc(100vh - 64px);
+  background: linear-gradient(0deg, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.6)),
+    url(/images/home/joshua-sortino-XMcoTHgNcQA-unsplash.jpg);
+}
+
+.inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.title {
+  margin-bottom: 18px;
+  font-size: 36px;
+  line-height: 1.5;
+}
+
+.text {
+  font-family: 'SUIT', sans-serif;
+  line-height: 1.5;
+}
+
+.textGap {
+  margin-bottom: 18px;
+}


### PR DESCRIPTION
## Summary
- continue page-by-page visual parity restoration on top of PR #58
- move onboarding, not-found, and will detail screens toward route-local CSS module styling
- reduce style bleed from shared primitives while the app router migration settles

## What changed
- added onboarding.module.css and moved onboarding layout styling there
- added will.module.css and moved will detail card/title/footer styling there
- added notfound.module.css and moved not-found screen styling there
- updated will detail/title/card components to use route-local styles

## Why a separate PR
PR #58 is the migration baseline. This PR is a narrower follow-up focused on parity restoration for a few user-facing pages.

## Verification
- code diff review for onboarding, not-found, and will detail slices
- branch pushes cleanly and is ready for continued parity work

## Notes
- this PR intentionally focuses on local page styles, not full shared primitive refactors yet